### PR TITLE
Add `sshpass`, fix rootless builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.13 as main
 
 RUN set -eux \
- && apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates \
+ && apk --update add bash openssh-client sshpass ruby git ruby-json python3 py3-pip openssl ca-certificates \
  && apk --update add --virtual \
       build-dependencies \
       build-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux \
  && mkdir -p /etc/ansible \
  && echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 
-COPY assets/ /opt/resource/
+COPY --chmod=755 assets/ /opt/resource/
 
 RUN echo "---"                   >> requirements.yml \
  && echo "collections:"          >> requirements.yml \


### PR DESCRIPTION
To allow for credential-based Ansible workflows, `sshpass` is needed. Add it to the image accordingly.

Furthermore, rootless image builds (e.g. using Podman) caused unexpected file permissions of the assets as revealed by the final rspec tests.